### PR TITLE
Relax composer dependency to allow Neos 5.3 aswell

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "neos/neos": "^7.0 || dev-master"
+        "neos/neos": "^5.3 || ^7.0 || dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",


### PR DESCRIPTION
I testet this in a 5.3 project and it works as expected.