### PR TITLE
TASK: Pin CI to use Node 16

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,11 @@ jobs:
   jest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
       - name: Install node modules
         run: yarn
       - name: Bootstrap Lerna


### PR DESCRIPTION
Fixes `Error: error:0308010C:digital envelope routines::unsupported`