### PR TITLE
FEATURE Inspector link value object property 

### DIFF
--- a/.github/workflows/CI-Server.yml
+++ b/.github/workflows/CI-Server.yml
@@ -22,6 +22,8 @@ jobs:
             neos-version: 7.3
           - php-version: 8.1
             neos-version: 8.3
+          - php-version: 8.3
+            neos-version: 8.3
 
     steps:
       - name: Checkout code

--- a/Classes/Link.php
+++ b/Classes/Link.php
@@ -79,7 +79,7 @@ final class Link implements \JsonSerializable
         array $rel
     ): self {
         $relMap = [];
-        foreach ($rel ?? [] as $value) {
+        foreach ($rel as $value) {
             $relMap[trim(strtolower($value))] = true;
         }
         $trimmedTarget = $target !== null ? trim($target) : '';
@@ -92,7 +92,7 @@ final class Link implements \JsonSerializable
     }
 
     /**
-     * @param array<string, string> $array
+     * @param array<string, mixed> $array
      */
     public static function fromArray(array $array): self
     {
@@ -147,10 +147,7 @@ final class Link implements \JsonSerializable
         );
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
         return [
             'href' => $this->href->__toString(),

--- a/Classes/Link.php
+++ b/Classes/Link.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\Archaeopteryx;
+
+use GuzzleHttp\Psr7\Uri;
+use Neos\Flow\Annotations as Flow;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Link value object for node properties,
+ *
+ * ```yaml
+ * My.Content:
+ *   properties:
+ *     link:
+ *       type: 'Sitegeist\Archaeopteryx\Link'
+ * ```
+ *
+ * @Flow\Proxy(false)
+ */
+final class Link implements \JsonSerializable
+{
+    public const TARGET_SELF = '_self';
+    public const TARGET_BLANK = '_blank';
+
+    public const REL_NOOPENER = 'noopener';
+    public const REL_NOFOLLOW = 'nofollow';
+
+    /**
+     * @param array<int, string> $relNofollow
+     */
+    private function __construct(
+        public readonly UriInterface $href,
+        public readonly ?string $title,
+        public readonly ?string $targetBlank,
+        public readonly ?array $relNofollow
+    ) {
+    }
+
+    /**
+     * @param array<int, string> $relNofollow
+     */
+    public static function create(
+        UriInterface $href,
+        ?string $title,
+        ?string $targetBlank,
+        ?array $relNofollow
+    ): self {
+        return new self(
+            $href,
+            $title,
+            $targetBlank,
+            $relNofollow
+        );
+    }
+
+    /**
+     * @param array<string, string> $array
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            new Uri($array['href']),
+            $array['title'] ?? null,
+            $array['targetBlank'] ?? null,
+            $array['relNofollow'] ?? null,
+        );
+    }
+
+    public static function fromString(string $string): self
+    {
+        return new self(
+            new Uri($string),
+            null,
+            null,
+            null,
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'href' => $this->href->__toString(),
+            'title' => $this->title,
+            'targetBlank' => $this->targetBlank,
+            'relNofollow' => $this->relNofollow,
+        ];
+    }
+}

--- a/Classes/Link.php
+++ b/Classes/Link.php
@@ -9,50 +9,85 @@ use Neos\Flow\Annotations as Flow;
 use Psr\Http\Message\UriInterface;
 
 /**
- * Link value object for node properties,
+ * Link value object modeled partially after the html spec for <a> tags.
+ *
+ * This Link can be used also as node property:
  *
  * ```yaml
  * My.Content:
  *   properties:
  *     link:
  *       type: 'Sitegeist\Archaeopteryx\Link'
+ *       ui:
+ *         inspector:
+ *           editorOptions:
+ *             anchor: true
+ *             title: true
+ *             targetBlank: true
+ *             relNofollow: true
  * ```
+ *
+ * Note that currently the link editor can only handle and write to
+ * the property {@see Link::$target} "_blank" | null
+ * and to {@see Link::$rel} ["noopener"] | null
+ *
+ * The Link values can be accessed in Fusion the following:
+ *
+ * ```fusion
+ * href = ${q(node).property("link").href}
+ * title = ${q(node).property("link").title}
+ * # ...
+ * ```
+ *
+ * In case you need to cast the uri in {@see Link::$href} explicitly to a string
+ * you can use: `String.toString(link.href)`
  *
  * @Flow\Proxy(false)
  */
 final class Link implements \JsonSerializable
 {
+    /**
+     * A selection of frequently used target attribute values
+     */
     public const TARGET_SELF = '_self';
     public const TARGET_BLANK = '_blank';
 
+    /**
+     * A selection of frequently used rel attribute values
+     */
     public const REL_NOOPENER = 'noopener';
     public const REL_NOFOLLOW = 'nofollow';
 
     /**
-     * @param array<int, string> $relNofollow
+     * @param array<int, string> $rel
      */
     private function __construct(
         public readonly UriInterface $href,
         public readonly ?string $title,
-        public readonly ?string $targetBlank,
-        public readonly ?array $relNofollow
+        public readonly ?string $target,
+        public readonly array $rel
     ) {
     }
 
     /**
-     * @param array<int, string> $relNofollow
+     * @param array<int, string> $rel
      */
     public static function create(
         UriInterface $href,
         ?string $title,
-        ?string $targetBlank,
-        ?array $relNofollow
+        ?string $target,
+        array $rel
     ): self {
+        $relMap = [];
+        foreach ($rel ?? [] as $value) {
+            $relMap[trim(strtolower($value))] = true;
+        }
+        $trimmedTarget = $target !== null ? trim($target) : '';
         return new self(
             $href,
             $title,
-            $targetBlank,
-            $relNofollow
+            $trimmedTarget !== '' ? strtolower($trimmedTarget) : null,
+            array_keys($relMap)
         );
     }
 
@@ -61,21 +96,54 @@ final class Link implements \JsonSerializable
      */
     public static function fromArray(array $array): self
     {
-        return new self(
+        return self::create(
             new Uri($array['href']),
             $array['title'] ?? null,
-            $array['targetBlank'] ?? null,
-            $array['relNofollow'] ?? null,
+            $array['target'] ?? null,
+            $array['rel'] ?? [],
         );
     }
 
     public static function fromString(string $string): self
     {
-        return new self(
+        return self::create(
             new Uri($string),
             null,
             null,
-            null,
+            [],
+        );
+    }
+
+    public function withTitle(?string $title): self
+    {
+        return self::create(
+            $this->href,
+            $title,
+            $this->target,
+            $this->rel
+        );
+    }
+
+    public function withTarget(?string $target): self
+    {
+        return self::create(
+            $this->href,
+            $this->title,
+            $target,
+            $this->rel
+        );
+    }
+
+    /**
+     * @param array<int, string> $rel
+     */
+    public function withRel(array $rel): self
+    {
+        return self::create(
+            $this->href,
+            $this->title,
+            $this->target,
+            $rel
         );
     }
 
@@ -87,8 +155,8 @@ final class Link implements \JsonSerializable
         return [
             'href' => $this->href->__toString(),
             'title' => $this->title,
-            'targetBlank' => $this->targetBlank,
-            'relNofollow' => $this->relNofollow,
+            'target' => $this->target,
+            'rel' => $this->rel,
         ];
     }
 }

--- a/Classes/LinkToArrayForNeosUiConverter.php
+++ b/Classes/LinkToArrayForNeosUiConverter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\Archaeopteryx;
+
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
+use Neos\Flow\Property\TypeConverter\ArrayFromObjectConverter;
+
+/**
+ * Until we only support Neos 8.3.10 and beyond we need this patch.
+ *
+ * See bug {@see https://github.com/neos/neos-development-collection/pull/4638}
+ *
+ * We must prevent that in {@see \Neos\Neos\Service\Mapping\NodePropertyConverterService::convertValue} the {@see Link}
+ * is converted via the {@see ArrayFromObjectConverter} as this fails when converting the {@see \GuzzleHttp\Psr7\Uri} in {@see Link::$href}.
+ *
+ * @deprecated
+ */
+class LinkToArrayForNeosUiConverter extends AbstractTypeConverter
+{
+    protected $sourceTypes = [Link::class];
+
+    protected $targetType = 'array';
+
+    protected $priority = 100;
+
+    /**
+     * @param array<string,mixed> $convertedChildProperties
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        if (!$source instanceof Link) {
+            throw new \InvalidArgumentException('Expected argument $source to be of type Link, got: ' . get_debug_type($source), 1697972165);
+        }
+        return $source->jsonSerialize();
+    }
+}

--- a/Configuration/Settings.Neos.Ui.yaml
+++ b/Configuration/Settings.Neos.Ui.yaml
@@ -1,5 +1,13 @@
 Neos:
   Neos:
+    userInterface:
+      inspector:
+        dataTypes:
+          Sitegeist\Archaeopteryx\Link:
+            # the option `typeConverter` must not be specified here.
+            # from array|string to Link the Neos\Flow\Property\TypeConverter\DenormalizingObjectConverter is used
+            # for Link to array the NodePropertyConverterService natively just works with the JsonSerializable
+            editor: Sitegeist.Archaeopteryx/Inspector/Editors/ValueObjectLinkEditor
     Ui:
       resources:
         javascript:

--- a/Neos.Ui/inspector-editor/src/InspectorEditor.tsx
+++ b/Neos.Ui/inspector-editor/src/InspectorEditor.tsx
@@ -6,113 +6,12 @@ import {ILinkType, useLinkTypeForHref, useEditorTransactions, Deletable} from '@
 import {ErrorBoundary, decodeError} from '@sitegeist/archaeopteryx-error-handling';
 import {ILink} from '@sitegeist/archaeopteryx-core/src/domain';
 import {ILinkOptions} from '@sitegeist/archaeopteryx-core/src/domain';
-
-/**
- * Translates to php's {@see \Sitegeist\Archaeopteryx\Link}
- */
-type LinkValueObject = {
-    href: string;
-    title?: string;
-    target?: string;
-    rel: string[];
-};
-
-export enum LinkDataType {
-    string,
-    valueObject
-}
-
-/**
- * These are the possible formats from {@see LinkDataType} to store the link in the Node.
- *  The string is the default
- *  The valueObject is on php side this vo: {@see \Sitegeist\Archaeopteryx\Link}
- */
-type SerializeableLink = {
-    dataType: LinkDataType.valueObject,
-    value: LinkValueObject | null
-} | {
-    dataType: LinkDataType.string,
-    value: string | null
-}
-
-/**
- * Determine based on the property type of the schema how to interpret the property value
- */
-const resolveCurrentSerializedLink = (value: any, linkDataType: LinkDataType): SerializeableLink => {
-    if (linkDataType === LinkDataType.valueObject) {
-        // @ts-ignore
-        const linkArray = (typeof value === "object" && value !== null && "href" in value && typeof value.href === "string") ? value as LinkValueObject : null;
-        return {
-            dataType: linkDataType,
-            value: linkArray
-        }
-    }
-    return {
-        dataType: linkDataType,
-        value: typeof value === "string" ? (value || null) : null
-    }
-}
-
-/**
- * Convert the {@see SerializeableLink} to the editor representation.
- * For example the anchor field is in the value object encoded into the href, but for editing treated separately.
- *
- * Counterpart of {@see convertILinkToSerializedLinkValue}
- */
-const serializedLinkToILink = (serializedLink: SerializeableLink): ILink | null => {
-    if (serializedLink.value === null) {
-        return null;
-    }
-    switch (serializedLink.dataType) {
-        case LinkDataType.valueObject:
-            const linkValueObject = serializedLink.value;
-
-            const [baseHref, hash] = linkValueObject.href.split('#', 2);
-
-            return {
-                href: baseHref,
-                options: {
-                    anchor: hash || undefined,
-                    title: linkValueObject.title || undefined,
-                    targetBlank: linkValueObject.target ? linkValueObject.target === '_blank' : undefined,
-                    relNofollow: linkValueObject.rel.includes('nofollow'),
-                }
-            };
-        case LinkDataType.string:
-            const [baseHref2, hash2] = serializedLink.value.split('#', 2);
-
-            return {
-                href: baseHref2,
-                options: {
-                    anchor: hash2 || undefined,
-                }
-            };
-    }
-}
-
-/**
- * Convert the editor representation of the link to the {@see SerializeableLink.value}
- * For example the anchor field is for editing treated separately but in the value object encoded into the href.
- *
- * Counterpart of {@see serializedLinkToILink}
- */
-const convertILinkToSerializedLinkValue = (link: ILink, dataType: LinkDataType): any => {
-    const href = link.options?.anchor
-        ? `${link.href}#${link.options.anchor}`
-        : link.href;
-
-    switch (dataType) {
-        case LinkDataType.valueObject:
-            return {
-                href: href,
-                title: link.options?.title,
-                target: link.options?.targetBlank ? '_blank' : undefined,
-                rel: link.options?.relNofollow ? ['nofollow'] : [],
-            };
-        case LinkDataType.string:
-            return href;
-    }
-}
+import {
+    convertILinkToSerializedLinkValue,
+    LinkDataType,
+    resolveSerializedLinkFromValue,
+    serializedLinkToILink
+} from "./serialisation";
 
 export type EditorProps = {
     options?: {
@@ -133,7 +32,7 @@ export const createInspectorEditor = (dataType: LinkDataType) => (props: EditorP
     const i18n = useI18n();
     const tx = useEditorTransactions();
 
-    const serializedLink = resolveCurrentSerializedLink(props.value, dataType);
+    const serializedLink = resolveSerializedLinkFromValue(props.value, dataType);
 
     const linkType = useLinkTypeForHref(
         serializedLink.dataType === LinkDataType.valueObject ? serializedLink.value?.href ?? null : serializedLink.value

--- a/Neos.Ui/inspector-editor/src/index.tsx
+++ b/Neos.Ui/inspector-editor/src/index.tsx
@@ -4,7 +4,8 @@ import {SynchronousRegistry} from '@neos-project/neos-ui-extensibility';
 import {INeosContextProperties, NeosContext} from '@sitegeist/archaeopteryx-neos-bridge';
 import {EditorContext, IEditor} from '@sitegeist/archaeopteryx-core';
 
-import {createInspectorEditor, LinkDataType} from './InspectorEditor';
+import {createInspectorEditor} from './InspectorEditor';
+import {LinkDataType} from "./serialisation";
 
 export function registerInspectorEditors(
     neosContextProperties: INeosContextProperties,

--- a/Neos.Ui/inspector-editor/src/index.tsx
+++ b/Neos.Ui/inspector-editor/src/index.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import {SynchronousRegistry} from '@neos-project/neos-ui-extensibility';
 
 import {INeosContextProperties, NeosContext} from '@sitegeist/archaeopteryx-neos-bridge';
-import {IEditor, EditorContext} from '@sitegeist/archaeopteryx-core';
+import {EditorContext, IEditor} from '@sitegeist/archaeopteryx-core';
 
-import {InspectorEditor} from './InspectorEditor';
+import {createInspectorEditor, LinkDataType} from './InspectorEditor';
 
-export function registerInspectorEditor(
+export function registerInspectorEditors(
     neosContextProperties: INeosContextProperties,
     editor: IEditor
 ): void {
@@ -25,11 +25,21 @@ export function registerInspectorEditor(
         return;
     }
 
+    editorsRegistry.set('Sitegeist.Archaeopteryx/Inspector/Editors/ValueObjectLinkEditor', {
+        component: (props: any) => (
+            <NeosContext.Provider value={neosContextProperties}>
+                <EditorContext.Provider value={editor}>
+                    {React.createElement(createInspectorEditor(LinkDataType.valueObject), props)}
+                </EditorContext.Provider>
+            </NeosContext.Provider>
+        )
+    });
+
     editorsRegistry.set('Sitegeist.Archaeopteryx/Inspector/Editors/LinkEditor', {
         component: (props: any) => (
             <NeosContext.Provider value={neosContextProperties}>
                 <EditorContext.Provider value={editor}>
-                    {React.createElement(InspectorEditor, props)}
+                    {React.createElement(createInspectorEditor(LinkDataType.string), props)}
                 </EditorContext.Provider>
             </NeosContext.Provider>
         )

--- a/Neos.Ui/inspector-editor/src/serialisation.test.js
+++ b/Neos.Ui/inspector-editor/src/serialisation.test.js
@@ -1,0 +1,368 @@
+import {describe, it} from 'node:test';
+import {deepEqual, equal} from 'node:assert/strict';
+import {convertILinkToSerializedLinkValue, LinkDataType, serializedLinkToILink, resolveSerializedLinkFromValue} from "./serialisation";
+
+describe('InspectorEditor: serialisation', () => {
+    it('resolveSerializedLinkFromValue for string ', () => {
+        deepEqual(
+            resolveSerializedLinkFromValue(null, LinkDataType.string),
+            {
+                dataType: LinkDataType.string,
+                value: null
+            }
+        )
+
+        deepEqual(
+            resolveSerializedLinkFromValue('', LinkDataType.string),
+            {
+                dataType: LinkDataType.string,
+                value: null
+            }
+        )
+
+        deepEqual(
+            resolveSerializedLinkFromValue('http://marchenry.de', LinkDataType.string),
+            {
+                dataType: LinkDataType.string,
+                value: "http://marchenry.de"
+            }
+        )
+
+        deepEqual(
+            resolveSerializedLinkFromValue('http://marchenry.de#tiefseeanker', LinkDataType.string),
+            {
+                dataType: LinkDataType.string,
+                value: "http://marchenry.de#tiefseeanker"
+            }
+        )
+    });
+
+    it('serializedLinkToILink for string ', () => {
+        equal(
+            serializedLinkToILink({dataType: LinkDataType.string, value: null}),
+            null
+        )
+
+        equal(
+            serializedLinkToILink({dataType: LinkDataType.string, value: ""}),
+            null
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.string, value: "http://marchenry.de"}),
+            {
+                href: "http://marchenry.de",
+                options: {
+                    anchor: undefined
+                }
+            }
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.string, value: "http://marchenry.de#tiefseeanker"}),
+            {
+                href: "http://marchenry.de",
+                options: {
+                    anchor: 'tiefseeanker'
+                }
+            }
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.string, value: "http://marchenry.de/some/path?query=foo#tiefseeanker"}),
+            {
+                href: "http://marchenry.de/some/path?query=foo",
+                options: {
+                    anchor: 'tiefseeanker'
+                }
+            }
+        )
+    });
+
+    it('convertILinkToSerializedLinkValue for string ', () => {
+        equal(
+            convertILinkToSerializedLinkValue({href: "http://marchenry.de"}, LinkDataType.string),
+            "http://marchenry.de"
+        )
+
+        equal(
+            convertILinkToSerializedLinkValue({
+                href: "http://marchenry.de",
+                options: {
+                    anchor: 'tiefseeanker'
+                }
+            }, LinkDataType.string),
+            "http://marchenry.de#tiefseeanker"
+        )
+
+        // all other parts are discarded
+        equal(
+            convertILinkToSerializedLinkValue({
+                href: "http://marchenry.de",
+                options: {
+                    anchor: 'tiefseeanker',
+                    relNofollow: true,
+                    targetBlank: true,
+                    title: 'my title'
+                }
+            }, LinkDataType.string),
+            "http://marchenry.de#tiefseeanker"
+        )
+    });
+
+    it('resolveSerializedLinkFromValue for valueObject ', () => {
+        deepEqual(
+            resolveSerializedLinkFromValue(null, LinkDataType.valueObject),
+            {
+                dataType: LinkDataType.valueObject,
+                value: null
+            }
+        )
+
+        deepEqual(
+            resolveSerializedLinkFromValue('', LinkDataType.valueObject),
+            {
+                dataType: LinkDataType.valueObject,
+                value: null
+            }
+        )
+
+        deepEqual(
+            resolveSerializedLinkFromValue([], LinkDataType.valueObject),
+            {
+                dataType: LinkDataType.valueObject,
+                value: null
+            }
+        )
+
+        deepEqual(
+            resolveSerializedLinkFromValue({}, LinkDataType.valueObject),
+            {
+                dataType: LinkDataType.valueObject,
+                value: null
+            }
+        )
+
+        deepEqual(
+            resolveSerializedLinkFromValue({gibberish: 'tja'}, LinkDataType.valueObject),
+            {
+                dataType: LinkDataType.valueObject,
+                value: null
+            }
+        )
+
+        deepEqual(
+            resolveSerializedLinkFromValue({
+                href: 'http://marchenry.de'
+            }, LinkDataType.valueObject),
+            {
+                dataType: LinkDataType.valueObject,
+                value: {
+                    href: "http://marchenry.de"
+                }
+            }
+        )
+
+        deepEqual(
+            resolveSerializedLinkFromValue({
+                href: "http://marchenry.de#tiefseeanker",
+                title: 'my title',
+                target: '_blank',
+                rel: ['nofollow'],
+            }, LinkDataType.valueObject),
+            {
+                dataType: LinkDataType.valueObject,
+                value: {
+                    href: "http://marchenry.de#tiefseeanker",
+                    title: 'my title',
+                    target: '_blank',
+                    rel: ['nofollow'],
+                }
+            }
+        )
+    });
+
+
+    it('serializedLinkToILink for valueObject ', () => {
+        equal(
+            serializedLinkToILink({dataType: LinkDataType.valueObject, value: null}),
+            null
+        )
+
+        equal(
+            serializedLinkToILink({dataType: LinkDataType.valueObject, value: ""}),
+            null
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.valueObject, value: {
+                href: "http://marchenry.de",
+                title: undefined,
+                target: undefined,
+                rel: [],
+            }}),
+            {
+                href: "http://marchenry.de",
+                options: {
+                    anchor: undefined,
+                    relNofollow: false,
+                    targetBlank: undefined,
+                    title: undefined
+                }
+            }
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.valueObject, value: {
+                href: "http://marchenry.de#tiefseeanker",
+                title: undefined,
+                target: undefined,
+                rel: [],
+            }}),
+            {
+                href: "http://marchenry.de",
+                options: {
+                    anchor: 'tiefseeanker',
+                    relNofollow: false,
+                    targetBlank: undefined,
+                    title: undefined
+                }
+            }
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.valueObject, value: {
+                    href: "http://marchenry.de",
+                    title: 'some title',
+                    target: undefined,
+                    rel: [],
+                }}),
+            {
+                href: "http://marchenry.de",
+                options: {
+                    anchor: undefined,
+                    relNofollow: false,
+                    targetBlank: undefined,
+                    title: 'some title'
+                }
+            }
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.valueObject, value: {
+                    href: "http://marchenry.de",
+                    title: undefined,
+                    target: '_self',
+                    rel: [],
+                }}),
+            {
+                href: "http://marchenry.de",
+                options: {
+                    anchor: undefined,
+                    relNofollow: false,
+                    targetBlank: false,
+                    title: undefined
+                }
+            }
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.valueObject, value: {
+                    href: "http://marchenry.de",
+                    title: undefined,
+                    target: '_blank',
+                    rel: [],
+                }}),
+            {
+                href: "http://marchenry.de",
+                options: {
+                    anchor: undefined,
+                    relNofollow: false,
+                    targetBlank: true,
+                    title: undefined
+                }
+            }
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.valueObject, value: {
+                    href: "http://marchenry.de",
+                    title: undefined,
+                    target: undefined,
+                    rel: ['noopener'],
+                }}),
+            {
+                href: "http://marchenry.de",
+                options: {
+                    anchor: undefined,
+                    relNofollow: false,
+                    targetBlank: undefined,
+                    title: undefined
+                }
+            }
+        )
+
+        deepEqual(
+            serializedLinkToILink({dataType: LinkDataType.valueObject, value: {
+                    href: "http://marchenry.de",
+                    title: undefined,
+                    target: undefined,
+                    rel: ['nofollow'],
+                }}),
+            {
+                href: "http://marchenry.de",
+                options: {
+                    anchor: undefined,
+                    relNofollow: true,
+                    targetBlank: undefined,
+                    title: undefined
+                }
+            }
+        )
+    });
+
+    it('convertILinkToSerializedLinkValue for value object ', () => {
+        deepEqual(
+            convertILinkToSerializedLinkValue({href: "http://marchenry.de"}, LinkDataType.valueObject),
+            {
+                href: "http://marchenry.de",
+                title: undefined,
+                target: undefined,
+                rel: [],
+            }
+        )
+
+        deepEqual(
+            convertILinkToSerializedLinkValue({
+                href: "http://marchenry.de",
+                options: {
+                    anchor: 'tiefseeanker'
+                }
+            }, LinkDataType.valueObject),
+            {
+                href: "http://marchenry.de#tiefseeanker",
+                title: undefined,
+                target: undefined,
+                rel: [],
+            }
+        )
+
+        deepEqual(
+            convertILinkToSerializedLinkValue({
+                href: "http://marchenry.de",
+                options: {
+                    anchor: 'tiefseeanker',
+                    relNofollow: true,
+                    targetBlank: true,
+                    title: 'my title'
+                }
+            }, LinkDataType.valueObject),
+            {
+                href: "http://marchenry.de#tiefseeanker",
+                title: 'my title',
+                target: '_blank',
+                rel: ['nofollow'],
+            }
+        )
+    });
+});

--- a/Neos.Ui/inspector-editor/src/serialisation.ts
+++ b/Neos.Ui/inspector-editor/src/serialisation.ts
@@ -1,0 +1,108 @@
+import {ILink} from "@sitegeist/archaeopteryx-core/src/domain";
+
+/**
+ * Translates to php's {@see \Sitegeist\Archaeopteryx\Link}
+ */
+export type LinkValueObject = {
+    href: string;
+    title?: string;
+    target?: string;
+    rel: string[];
+};
+
+export enum LinkDataType {
+    string,
+    valueObject
+}
+
+/**
+ * These are the possible formats from {@see LinkDataType} to store the link in the Node.
+ *  The string is the default
+ *  The valueObject is on php side this vo: {@see \Sitegeist\Archaeopteryx\Link}
+ */
+export type SerializeableLink = {
+    dataType: LinkDataType.valueObject,
+    value: LinkValueObject | null
+} | {
+    dataType: LinkDataType.string,
+    value: string | null
+}
+
+/**
+ * Determine based on the property type of the schema how to interpret the property value
+ */
+export const resolveSerializedLinkFromValue = (value: any, linkDataType: LinkDataType): SerializeableLink => {
+    if (linkDataType === LinkDataType.valueObject) {
+        // @ts-ignore
+        const linkArray = (typeof value === "object" && value !== null && "href" in value && typeof value.href === "string") ? value as LinkValueObject : null;
+        return {
+            dataType: linkDataType,
+            value: linkArray
+        }
+    }
+    return {
+        dataType: linkDataType,
+        value: typeof value === "string" ? (value || null) : null
+    }
+}
+
+/**
+ * Convert the {@see SerializeableLink} to the editor representation.
+ * For example the anchor field is in the value object encoded into the href, but for editing treated separately.
+ *
+ * Counterpart of {@see convertILinkToSerializedLinkValue}
+ */
+export const serializedLinkToILink = (serializedLink: SerializeableLink): ILink | null => {
+    if (!serializedLink.value) {
+        return null;
+    }
+    switch (serializedLink.dataType) {
+        case LinkDataType.valueObject:
+            const linkValueObject = serializedLink.value;
+
+            const [baseHref, hash] = linkValueObject.href.split('#', 2);
+
+            return {
+                href: baseHref,
+                options: {
+                    anchor: hash || undefined,
+                    title: linkValueObject.title || undefined,
+                    targetBlank: linkValueObject.target ? linkValueObject.target === '_blank' : undefined,
+                    relNofollow: linkValueObject.rel.includes('nofollow'),
+                }
+            };
+        case LinkDataType.string:
+            const [baseHref2, hash2] = serializedLink.value.split('#', 2);
+
+            return {
+                href: baseHref2,
+                options: {
+                    anchor: hash2 || undefined,
+                }
+            };
+    }
+}
+
+/**
+ * Convert the editor representation of the link to the {@see SerializeableLink.value}
+ * For example the anchor field is for editing treated separately but in the value object encoded into the href.
+ *
+ * Counterpart of {@see serializedLinkToILink}
+ */
+export const convertILinkToSerializedLinkValue = (link: ILink, dataType: LinkDataType): any => {
+    const href = link.options?.anchor
+        ? `${link.href}#${link.options.anchor}`
+        : link.href;
+
+    switch (dataType) {
+        case LinkDataType.valueObject:
+            return {
+                href: href,
+                title: link.options?.title,
+                target: link.options?.targetBlank ? '_blank' : undefined,
+                rel: link.options?.relNofollow ? ['nofollow'] : [],
+            };
+        case LinkDataType.string:
+            return href;
+    }
+}

--- a/Neos.Ui/plugin/src/manifest.js
+++ b/Neos.Ui/plugin/src/manifest.js
@@ -1,7 +1,7 @@
 import manifest from '@neos-project/neos-ui-extensibility';
 
 import {registerLinkTypes, registerDialog, createEditor} from '@sitegeist/archaeopteryx-core';
-import {registerInspectorEditor} from '@sitegeist/archaeopteryx-inspector-editor';
+import {registerInspectorEditors} from '@sitegeist/archaeopteryx-inspector-editor';
 import {registerLinkButton} from '@sitegeist/archaeopteryx-link-button';
 
 manifest('@sitegeist/archaeopteryx-plugin', {}, (globalRegistry, {store, configuration, routes}) => {
@@ -10,6 +10,6 @@ manifest('@sitegeist/archaeopteryx-plugin', {}, (globalRegistry, {store, configu
 
     registerLinkTypes(globalRegistry);
     registerDialog(neosContextProperties, editor);
-    registerInspectorEditor(neosContextProperties, editor);
+    registerInspectorEditors(neosContextProperties, editor);
     registerLinkButton(neosContextProperties, editor);
 });

--- a/README.md
+++ b/README.md
@@ -332,14 +332,17 @@ Use the preset in your link property, mixin or node type
   <img src="./Docs/Link Options.png">
 </p>
 
-In RTE context, Sitegeist.Archaeopteryx allows you to set some additional link options. These are:
+Sitegeist.Archaeopteryx allows you to set some additional link options. These are:
 
 * **Anchor:** This will add a string to the hash-section of the URL (the part after `#`)
 * **Title:** This will set the `title` attribute of the resulting `<a>`-Tag
 * **Open in new window:** This will set the `target` attribute of the resulting `<a>`-Tag to `_blank`
 * **rel="nofollow":** This will set the `rel` attribute of the resulting `<a>`-Tag to `nofollow`
 
-Not all Link Types support all of these options however. Here's an overview of what Link Type supports which options:
+Based on the context they might not be available. A simple inspector editor (`type: string`) for example cannot encode the "Title" option but only the "Anchor" by appending that to the link.
+The RTE supports all options and the inspector object `type: Sitegeist\Archaeopteryx\Link` too.
+
+Further, not all Link Types support all of these options. Here's an overview of what Link Type supports which options:
 
 | Link Type     | Supported Link Options                              |
 | ------------- | --------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ It is possible to disable one or more link type editors via the configuration fo
 
 ### Inspector Editor Configuration
 
+Using the basic `string` type:
+
 ```yaml
 'Vendor.Site:MyAwesomeNodeTypeWithALinkProperty':
   # ...
@@ -434,6 +436,38 @@ It is possible to disable one or more link type editors via the configuration fo
                 enabled: true
               'Sitegeist.Archaeopteryx:CustomLink':
                 enabled: false
+```
+
+Advanced usage with `Sitegeist\Archaeopteryx\Link` value object type:
+
+```yaml
+'Vendor.Site:MyAwesomeNodeTypeWithALinkValueObjectProperty':
+  # ...
+  properties:
+    link:
+      type: Sitegeist\Archaeopteryx\Link
+      ui:
+        inspector:
+          # ...
+          editorOptions:
+            # optionally enable link options, which will be encoded into the value object.
+            anchor: true
+            title: true
+            relNofollow: true
+            targetBlank: true
+```
+
+As the value object can serialize more than just the `href` we can also edit other link related options like `title` and the `target`.
+
+The link value object can be queried as usual. An example rendering would look the following:
+
+```
+link = ${q(node).property("link")}
+renderer = afx`
+    <a href={props.link.href} title={props.link.title} target={props.link.target} rel={props.link.rel} rel.@if={props.link.rel != []}>
+        My Text
+    </a>
+`
 ```
 
 ## Contribution

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "neos/neos": "~8.3.10"
+        "neos/neos": "^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "neos/neos": "^7.0 || ^8.0"
+        "php": "^8.1",
+        "neos/neos": "~8.3.10"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",


### PR DESCRIPTION
This feature introduces a php link value object which can also be used as node property with editor support.

Advanced Inspector Editor Configuration with `Sitegeist\Archaeopteryx\Link` value object type:

```yaml
'Vendor.Site:MyAwesomeNodeTypeWithALinkValueObjectProperty':
  # ...
  properties:
    link:
      type: Sitegeist\Archaeopteryx\Link
      ui:
        inspector:
          # ...
          editorOptions:
            # optionally enable link options, which will be encoded into the value object.
            anchor: true
            title: true
            relNofollow: true
            targetBlank: true
```

As the value object can serialize more than just the `href` we can also edit other link related options like `title` and the `target`.

The link value object can be queried as usual. An example rendering would look the following:

```
link = ${q(node).property("link")}
renderer = afx`
    <a href={props.link.href} title={props.link.title} target={props.link.target} rel={props.link.rel} rel.@if={props.link.rel != []}>
        My Text
    </a>
`
```

To try this feature out already, require this dev branch in your composer root:

```
composer require --no-update sitegeist/archaeopteryx:"dev-feature/inspectorLinkProperty as 1.6.0"
```

Demo Video:

https://github.com/sitegeist/Sitegeist.Archaeopteryx/assets/85400359/821b6b14-9e06-4727-9348-7235aece56ef


Requires: https://github.com/sitegeist/Sitegeist.Archaeopteryx/pull/89



