### PR TITLE
BUGFIX: Do not fail on empty dimension values

### DIFF
--- a/Classes/Application/GetChildrenForTreeNode/GetChildrenForTreeNodeQuery.php
+++ b/Classes/Application/GetChildrenForTreeNode/GetChildrenForTreeNodeQuery.php
@@ -45,11 +45,6 @@ final class GetChildrenForTreeNodeQuery
         is_string($array['workspaceName'])
             or throw new \InvalidArgumentException('Workspace name must be a string');
 
-        isset($array['dimensionValues'])
-            or throw new \InvalidArgumentException('Dimension values must be set');
-        is_array($array['dimensionValues'])
-            or throw new \InvalidArgumentException('Dimension values must be an array');
-
         isset($array['treeNodeId'])
             or throw new \InvalidArgumentException('Tree node id must be set');
         is_string($array['treeNodeId'])
@@ -63,7 +58,7 @@ final class GetChildrenForTreeNodeQuery
 
         return new self(
             workspaceName: $array['workspaceName'],
-            dimensionValues: $array['dimensionValues'],
+            dimensionValues: $array['dimensionValues'] ?? [],
             treeNodeId: NodeAggregateIdentifier::fromString($array['treeNodeId']),
             nodeTypeFilter: $array['nodeTypeFilter'] ?? '',
             linkableNodeTypes: NodeTypeNames::fromArray($array['linkableNodeTypes'] ?? []),

--- a/Classes/Application/GetNodeSummary/GetNodeSummaryQuery.php
+++ b/Classes/Application/GetNodeSummary/GetNodeSummaryQuery.php
@@ -41,11 +41,6 @@ final class GetNodeSummaryQuery
         is_string($array['workspaceName'])
             or throw new \InvalidArgumentException('Workspace name must be a string');
 
-        isset($array['dimensionValues'])
-            or throw new \InvalidArgumentException('Dimension values must be set');
-        is_array($array['dimensionValues'])
-            or throw new \InvalidArgumentException('Dimension values must be an array');
-
         isset($array['nodeId'])
             or throw new \InvalidArgumentException('Node id must be set');
         is_string($array['nodeId'])
@@ -53,7 +48,7 @@ final class GetNodeSummaryQuery
 
         return new self(
             workspaceName: $array['workspaceName'],
-            dimensionValues: $array['dimensionValues'],
+            dimensionValues: $array['dimensionValues'] ?? [],
             nodeId: NodeAggregateIdentifier::fromString($array['nodeId']),
         );
     }

--- a/Classes/Application/GetTree/GetTreeQuery.php
+++ b/Classes/Application/GetTree/GetTreeQuery.php
@@ -50,11 +50,6 @@ final class GetTreeQuery
         is_string($array['workspaceName'])
             or throw new \InvalidArgumentException('Workspace name must be a string');
 
-        isset($array['dimensionValues'])
-            or throw new \InvalidArgumentException('Dimension values must be set');
-        is_array($array['dimensionValues'])
-            or throw new \InvalidArgumentException('Dimension values must be an array');
-
         isset($array['startingPoint'])
             or throw new \InvalidArgumentException('Starting point must be set');
         is_string($array['startingPoint'])
@@ -85,7 +80,7 @@ final class GetTreeQuery
 
         return new self(
             workspaceName: $array['workspaceName'],
-            dimensionValues: $array['dimensionValues'],
+            dimensionValues: $array['dimensionValues'] ?? [],
             startingPoint: NodePath::fromString($array['startingPoint']),
             loadingDepth: $array['loadingDepth'],
             baseNodeTypeFilter: $array['baseNodeTypeFilter'] ?? '',


### PR DESCRIPTION
Fixes #66. I disabled the check in the query DTOs and fall back to an empty array. 

The reason the parameter is entirely missing and not just an empty array is found [here](https://github.com/sitegeist/Sitegeist.Archaeopteryx/blob/a1f2e509a6915bcd533c24a79ba6691b393f451f/Neos.Ui/custom-node-tree/src/infrastructure/http/getTree.ts#L44-L53):

```tsx
for (const [dimensionName, fallbackChain] of Object.entries(
        query.dimensionValues
    )) {
        for (const fallbackValue of fallbackChain) {
            searchParams.set(
                `dimensionValues[${dimensionName}][]`,
                fallbackValue
            );
        }
    }
```

If `query.dimensionValues` is empty, there is no search parameter added. 

Another solution would be to improve the client-side passing of the parameter by passing an actually empty array and keep the PHP checks instead. 