### PR TITLE
FIX: z-Index to be above richtTextEditor but below SelectBox dropdown

### DIFF
--- a/Neos.Ui/core/src/presentation/Modal.tsx
+++ b/Neos.Ui/core/src/presentation/Modal.tsx
@@ -15,7 +15,7 @@ import {Dialog} from '@neos-project/react-ui-components';
 // fix for the native Dialog in Neos UI will follow soon.
 //
 const StyledDialog = styled(Dialog)`
-    z-index: 100;
+    z-index: 69;
 
     [class*="_dialog__contentsPosition "],
     [class$="_dialog__contentsPosition"] {


### PR DESCRIPTION
This PR updates the z-index of the modal to ensure it appears above the `RichTextEditor` but remains below the `SelectBox` dropdown. This adjustment resolves an issue where the modal was being obscured or improperly layered in certain UI scenarios.

**Bug Fix:**
This change also fixes the following issue: resolves #78

**Changes:**

Updated the z-index of the modal to improve UI layering behavior
Ensured compatibility with RichTextEditor and SelectBox components


![aja-de ddev site_neos_content_node=%2Fsites%2Fdsr-ajaresortsde%2Fnode-e9z2nlk70mgvh%40user-admin%3Blanguage%3Dde(Desktop)](https://github.com/user-attachments/assets/a6c8ef88-a760-4ba0-aa85-82d1e07daaaa)
