### PR TITLE
BUGFIX: Compatibility with Flowpack.Neos.FrontendLogin

### DIFF
--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -1,7 +1,4 @@
-#                                                                        #
-# Security policy for the Sitegeist.Archaeopteryx package                           #
-#                                                                        #
----
+
 privilegeTargets:
 
   'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
@@ -11,8 +8,7 @@ privilegeTargets:
 
 roles:
 
-    'Neos.Neos:AbstractEditor':
-      privileges:
-        -
-          privilegeTarget: 'Sitegeist.Archaeopteryx:ApiAccess'
-          permission: GRANT
+  'Neos.Neos:AbstractEditor':
+    privileges:
+      - privilegeTarget: 'Sitegeist.Archaeopteryx:ApiAccess'
+        permission: GRANT

--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -1,6 +1,6 @@
 -
   name: 'GetChildrenForTreeNode Query'
-  uriPattern: 'sitegeist/archaeopteryx/get-children-for-tree-node'
+  uriPattern: 'neos/archaeopteryx/get-children-for-tree-node'
   defaults:
     '@package': 'Sitegeist.Archaeopteryx'
     '@subpackage': 'Application\GetChildrenForTreeNode'
@@ -9,7 +9,7 @@
 
 -
   name: 'GetNodeSummary Query'
-  uriPattern: 'sitegeist/archaeopteryx/get-node-summary'
+  uriPattern: 'neos/archaeopteryx/get-node-summary'
   defaults:
     '@package': 'Sitegeist.Archaeopteryx'
     '@subpackage': 'Application\GetNodeSummary'
@@ -18,7 +18,7 @@
 
 -
   name: 'GetNodeTypeFilterOptions Query'
-  uriPattern: 'sitegeist/archaeopteryx/get-node-type-filter-options'
+  uriPattern: 'neos/archaeopteryx/get-node-type-filter-options'
   defaults:
     '@package': 'Sitegeist.Archaeopteryx'
     '@subpackage': 'Application\GetNodeTypeFilterOptions'
@@ -27,7 +27,7 @@
 
 -
   name: 'GetTree Query'
-  uriPattern: 'sitegeist/archaeopteryx/get-tree'
+  uriPattern: 'neos/archaeopteryx/get-tree'
   defaults:
     '@package': 'Sitegeist.Archaeopteryx'
     '@subpackage': 'Application\GetTree'

--- a/Neos.Ui/core/src/infrastructure/http/getNodeSummary.ts
+++ b/Neos.Ui/core/src/infrastructure/http/getNodeSummary.ts
@@ -55,7 +55,7 @@ export async function getNodeSummary(
         const response = await fetchWithErrorHandling.withCsrfToken(
             (csrfToken) => ({
                 url:
-                    "/sitegeist/archaeopteryx/get-node-summary?" +
+                    "/neos/archaeopteryx/get-node-summary?" +
                     searchParams.toString(),
                 method: "GET",
                 credentials: "include",

--- a/Neos.Ui/custom-node-tree/src/infrastructure/http/getChildrenForTreeNode.ts
+++ b/Neos.Ui/custom-node-tree/src/infrastructure/http/getChildrenForTreeNode.ts
@@ -53,7 +53,7 @@ export async function getChildrenForTreeNode(
         const response = await fetchWithErrorHandling.withCsrfToken(
             (csrfToken) => ({
                 url:
-                    "/sitegeist/archaeopteryx/get-children-for-tree-node?" +
+                    "/neos/archaeopteryx/get-children-for-tree-node?" +
                     searchParams.toString(),
                 method: "GET",
                 credentials: "include",

--- a/Neos.Ui/custom-node-tree/src/infrastructure/http/getNodeTypeFilterOptions.ts
+++ b/Neos.Ui/custom-node-tree/src/infrastructure/http/getNodeTypeFilterOptions.ts
@@ -38,7 +38,7 @@ export async function getNodeTypeFilterOptions(
         const response = await fetchWithErrorHandling.withCsrfToken(
             (csrfToken) => ({
                 url:
-                    "/sitegeist/archaeopteryx/get-node-type-filter-options?" +
+                    "/neos/archaeopteryx/get-node-type-filter-options?" +
                     searchParams.toString(),
                 method: "GET",
                 credentials: "include",

--- a/Neos.Ui/custom-node-tree/src/infrastructure/http/getTree.ts
+++ b/Neos.Ui/custom-node-tree/src/infrastructure/http/getTree.ts
@@ -70,7 +70,7 @@ export async function getTree(
         const response = await fetchWithErrorHandling.withCsrfToken(
             (csrfToken) => ({
                 url:
-                    "/sitegeist/archaeopteryx/get-tree?" +
+                    "/neos/archaeopteryx/get-tree?" +
                     searchParams.toString(),
                 method: "GET",
                 credentials: "include",


### PR DESCRIPTION
As described in https://github.com/Flowpack/Flowpack.Neos.FrontendLogin/issues/36 the backend like endpoints must start with neos instead of /sitegeist/