### PR TITLE
BUGFIX: rel no follow is not preserved #43

### DIFF
--- a/Neos.Ui/core/src/application/Dialog/Settings.tsx
+++ b/Neos.Ui/core/src/application/Dialog/Settings.tsx
@@ -13,7 +13,7 @@ export const Settings: React.FC<{
         anchor?: string
         title?: string
         targetBlank?: boolean
-        relNoFollow?: boolean
+        relNofollow?: boolean
     }
 }> = props => {
     const i18n = useI18n();
@@ -69,8 +69,8 @@ export const Settings: React.FC<{
                     {props.enabledLinkOptions.includes('relNofollow') ? (
                         <Field<boolean>
                             type="checkbox"
-                            name="options.relNoFollow"
-                            initialValue={Boolean(props.initialValue?.relNoFollow)}
+                            name="options.relNofollow"
+                            initialValue={Boolean(props.initialValue?.relNofollow)}
                             >
                             {({input}) => (
                                 <label>


### PR DESCRIPTION
due to a casing mistake the option is never shown after applying the change and reopening

```
inline:
  editorOptions:
    linking:
      relNofollow: true
```

now the option works correctly:

<img width="539" alt="image" src="https://github.com/user-attachments/assets/ea0ca038-22a0-4a68-b905-26f52195b8f0" />

